### PR TITLE
Explicitly use UTC

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,9 +41,9 @@
             window.onload = () => {
                 // Dates
                 const dates = [
-                    ["Theme reveal", new Date("2022-11-01")],
-                    ["Working time ends", new Date("2022-11-28T23:59")],
-                    ["Voting time ends", new Date("2022-11-28T23:59")],
+                    ["Theme reveal", new Date("2022-11-01T00:00Z")],
+                    ["Working time ends", new Date("2022-11-28T23:59Z")],
+                    ["Voting time ends", new Date("2022-11-28T23:59Z")],
                     ["Results", "Soon..."],
                 ];
 


### PR DESCRIPTION
> Date-only strings (e.g. "1970-01-01") are treated as UTC, while date-time strings (e.g. "1970-01-01T12:00") are treated as local. You are therefore also advised to make sure the input format is consistent between the two types.
<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date>

Appending a `Z` makes it UTC.